### PR TITLE
add environment variable NP_CONF_IGNORED_ACLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,17 +177,17 @@ The default runtime can be overridden via [Environment Variables](#environment-v
 The following environment variables are optional and can be used to override the default behavior of nix-portable at run-time.
 
 ```txt
-NP_DEBUG      (1 = debug msgs; 2 = 'set -x' for nix-portable)
-NP_GIT        specify path to the git executable
-NP_LOCATION   where to put the `.nix-portable` dir. (defaults to `$HOME`)
-NP_RUNTIME    which runtime to use (must be one of: nix, bwrap, proot)
-NP_NIX        specify the path to the static nix executable to use in case nix is selected as runtime
-NP_BWRAP      specify the path to the bwrap executable to use in case bwrap is selected as runtime
-NP_PROOT      specify the path to the proot executable to use in case proot is selected as runtime
-NP_RUN        override the complete command to run nix
-              (to use an unsupported runtime, or for debugging)
-              nix will then be executed like: $NP_RUN {nix-binary} {args...}
-
+NP_DEBUG          (1 = debug msgs; 2 = 'set -x' for nix-portable)
+NP_GIT            specify path to the git executable
+NP_LOCATION       where to put the `.nix-portable` dir. (defaults to `$HOME`)
+NP_RUNTIME        which runtime to use (must be one of: nix, bwrap, proot)
+NP_NIX            specify the path to the static nix executable to use in case nix is selected as runtime
+NP_BWRAP          specify the path to the bwrap executable to use in case bwrap is selected as runtime
+NP_PROOT          specify the path to the proot executable to use in case proot is selected as runtime
+NP_RUN            override the complete command to run nix
+                  (to use an unsupported runtime, or for debugging)
+                  nix will then be executed like: $NP_RUN {nix-binary} {args...}
+NP_CONF_IGNORED_ACLS   a spaces separated list that gets concatenated onte the `ignored-acls| setting in `nix.conf`
 ```
 
 ### Drawbacks / Considerations

--- a/default.nix
+++ b/default.nix
@@ -158,7 +158,7 @@ let
 
     NP_CONF_SANDBOX=\''${NP_CONF_SANDBOX:-false}
     NP_CONF_STORE=\''${NP_CONF_STORE:-auto}
-
+    NP_CONF_IGNORED_ACLS=\''${NP_CONF_IGNORED_ACLS:-}
 
     recreate_nix_conf(){
       mkdir -p "\$NIX_CONF_DIR"
@@ -167,7 +167,7 @@ let
       # static config
       echo "build-users-group = " >> \$dir/conf/nix.conf
       echo "experimental-features = nix-command flakes" >> \$dir/conf/nix.conf
-      echo "ignored-acls = security.selinux system.nfs4_acl" >> \$dir/conf/nix.conf
+      echo "ignored-acls = security.selinux system.nfs4_acl \$NP_CONF_IGNORED_ACLS" >> \$dir/conf/nix.conf
       echo "use-sqlite-wal = false" >> \$dir/conf/nix.conf
       echo "sandbox-paths = /bin/sh=\$dir/busybox/bin/busybox" >> \$dir/conf/nix.conf
 

--- a/flake.nix
+++ b/flake.nix
@@ -223,7 +223,7 @@
               announce = cmd: ''echo -e "\ntesting cmd: ${cmd}"'';
               escape = cmd: replaceStrings [''"''] [''\"''] cmd;
               mkCmd = runtime: cmd: let
-                vars = "NP_RUNTIME=${runtime} NP_DEBUG=$NP_DEBUG NP_MINIMAL=$NP_MINIMAL NP_LOCATION=/np_tmp";
+                vars = "NP_RUNTIME=${runtime} NP_DEBUG=$NP_DEBUG NP_MINIMAL=$NP_MINIMAL NP_LOCATION=/np_tmp NP_CONF_IGNORED_ACLS=$NP_CONF_IGNORED_ACLS";
               in ''
                 ${announce (escape cmd)}
                 $ssh "${vars} /home/test/nix-portable ${escape cmd}"


### PR DESCRIPTION
This allows to ignore additional acls, such as `lustre.lov` which might be present on HPC clusters.